### PR TITLE
Call poolboy:start_link instead of poolboy:start in start_link to attach...

### DIFF
--- a/src/cberl.erl
+++ b/src/cberl.erl
@@ -51,7 +51,7 @@ start_link(PoolName, NumCon, Host, Username, Password, BucketName, Transcoder) -
                 {max_overflow, 0}],
     PoolArgs = [{name, {local, PoolName}},
                 {worker_module, cberl_worker}] ++ SizeArgs,
-    poolboy:start(PoolArgs, [Host, Username, Password, BucketName, Transcoder]).
+    poolboy:start_link(PoolArgs, [Host, Username, Password, BucketName, Transcoder]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%
 %%% STORE OPERATIONS %%%


### PR DESCRIPTION
... pool to our supervision tree.

This was under the advisement of devious, creator of poolboy. My erlang-fu is a bit weak, but as I understand it the pid returned by start is not linked into the supervision tree, but by calling poolboy:start_link instead it is.
