### PR TITLE
fixed cberl:decode_query_resp/1 for reduced views

### DIFF
--- a/src/cberl.erl
+++ b/src/cberl.erl
@@ -300,13 +300,11 @@ query_args(Args) when is_list(Args) ->
 
 decode_query_resp({ok, Resp}) ->
     case jiffy:decode(Resp) of
-        {[{<<"total_rows">>, TotalRows},
-            {<<"rows">>,
-             Rows}]} ->
+        {[{<<"total_rows">>, TotalRows}, {<<"rows">>, Rows}]} ->
             {ok, {TotalRows, lists:map(fun ({Row}) -> Row end, Rows)}};
-        {[{<<"error">>,Error},
-          {<<"reason">>,
-           Reason}]} ->
+        {[{<<"rows">>, Rows}]} ->
+            {ok, {lists:map(fun ({Row}) -> Row end, Rows)}};
+        {[{<<"error">>,Error}, {<<"reason">>, Reason}]} ->
             {error, {view_error(Error), Reason}}
     end.
 


### PR DESCRIPTION
Hi,

This fixes an issue with `cberl:decode_query_resp/1` when calling `cberl:view/4` on a reduced couchbase view.

Couchbase queries do not include a key `total_rows` in the JSON response when a reduce function is applied to the targeted view, which makes `cberl:view/4` return an error due to the failed pattern matching, even though everything went as expected.

Thanks

(also, my editor probably stripped the file of its extra spaces :) )
