### PR TITLE
Minimal .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: erlang
+otp_release:
+  - 17.0
+  - R16B03-1
+  - R16B03
+  - R16B02
+  - R16B01
+  - R16B
+before_script:
+  - sudo wget -O /etc/apt/sources.list.d/couchbase.list http://packages.couchbase.com/ubuntu/couchbase-ubuntu1204.list
+  - sudo apt-get update
+  - sudo apt-get install libcouchbase2-libevent libcouchbase-dev --force-yes
+script: ./rebar compile && ./rebar skip_deps=true tests=cberl_transcoder_test eunit 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 CBERL
 ====
 
+[![Build Status](https://travis-ci.org/wcummings/cberl.svg?branch=master)](https://travis-ci.org/wcummings/cberl)
+
 NIF based Erlang bindings for couchbase based on libcouchbase. 
 CBERL is at early stage of development, it only supports very basic functionality. Please submit bugs and patches if you find any.
 Tested on mac, debian squeeze and amazon linux.


### PR DESCRIPTION
Just runs the tests that don't require couchbase to be running (and makes sure everything actually builds!)

We should be able to get travisci to setup couchbase, not sure how/if we have to handle configuration, @hlieberman might have some ideas.

We'll have to change the badge URL (not sure how to keep this different in my fork... could be annoying...)
