### PR TITLE
Return {ok,CAS::integer()} instead of ok for all store operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Make sure you have couchbase running on localhost or use cberl:new(Host) instead
     {ok, <0.33.0>}
     %% Poolname, Key, Expire - 0 for infinity, Value
     cberl:set(cberl_default, <<"fkey">>, 0, <<"cberl">>).
-    ok
+    {ok,CAS}
     cberl:get(cberl_default, <<"fkey">>).
     {<<"fkey">>, ReturnedCasValue, <<"cberl">>}
 

--- a/c_src/cb.c
+++ b/c_src/cb.c
@@ -181,7 +181,7 @@ ERL_NIF_TERM cb_store(ErlNifEnv* env, handle_t* handle, void* obj)
     if (cb.error != LCB_SUCCESS) {
         return return_lcb_error(env, cb.error);
     }
-    return A_OK(env);
+    return enif_make_tuple2(env, A_OK(env), enif_make_uint64(env, cb.cas));
 }
 
 void* cb_mget_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/src/cberl_nif.erl
+++ b/src/cberl_nif.erl
@@ -6,11 +6,9 @@
 -define(NIF_STUB, erlang:nif_error(nif_library_not_loaded)).
 
 init() ->
-    PrivDir = case code:priv_dir(?MODULE) of
+    PrivDir = case code:priv_dir(cberl) of
                   {error, bad_name} ->
-                      EbinDir = filename:dirname(code:which(?MODULE)),
-                      AppPath = filename:dirname(EbinDir),
-                      filename:join(AppPath, "priv");
+                      re:replace(code:which(?MODULE), "cberl.*", "cberl/priv",[{return,list}]);
                   Path ->
                       Path
               end,


### PR DESCRIPTION
This saves a roundtrip when you set/add an item that you'll want to modify later.

This is a backward-incompatible change, but it seems important enough and seems to be
a coding oversight as most of the work was already done (but thrown away) in store_callback().

If the compat break (along with a version bump) is not ok or too early, one possibility would be to wrap cberl:set/add/replace to just return 'ok' and let cberl:store return the full info. Another would be to turn the TranscoderOpts into Opts|[Opts] which would give us a flexible API extension mecanism going forward (arguably, if we're breaking compat, doing that strainght away and puting the expiration in the options would be a good thing).