### PR TITLE
Feature/n1ql

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Views
 cberl has support for querying views via the view/4 functions:
 
 ```erlang
-cberl:view(default, "all", "all", []).
+cberl:view(cberl_default, "all", "all", []).
 {ok,{1,
     [[{<<"id">>,<<"test">>},
     {<<"key">>,<<"test">>},

--- a/README.md
+++ b/README.md
@@ -75,6 +75,35 @@ cberl:view(cberl_default, "all", "all", []).
 
 Shorthand for foldl, foldr and foreach are also provided.
 
+N1QL
+-----
+
+cberl has support for N1QL queries via the n1ql/4 and n1ql/5 functions:
+
+```erlang
+Dog = {[{<<"type">>,<<"dog">>},
+  {<<"name">>,<<"tom">>},
+  {<<"age">>,5},
+  {<<"color">>,<<"white">>}]}.
+cberl:set(cberl_default, <<"tom">>, 0, Dog).
+cberl:n1ql(cberl_default, <<"SELECT * FROM default WHERE type=$1 and age=$2 and color=$3">>, [<<"\"dog\"">>, <<"5">>, <<"\"white\"">>], false).
+{ok,{[{<<"requestID">>,
+       <<"a00b80e8-aea8-4a23-a0a9-5aba26d2b48f">>},
+      {<<"signature">>,{[{<<"*">>,<<"*">>}]}},
+      {<<"results">>,[]},
+      {<<"status">>,<<"success">>},
+      {<<"metrics">>,
+       {[{<<"elapsedTime">>,<<"21.644116ms">>},
+         {<<"executionTime">>,<<"21.60625ms">>},
+         {<<"resultCount">>,1},
+         {<<"resultSize">>,171}]}}]},
+    [{[{<<"default">>,
+        {[{<<"age">>,5},
+          {<<"color">>,<<"white">>},
+          {<<"name">>,<<"tom">>},
+          {<<"type">>,<<"dog">>}]}}]}]}
+```
+
 Custom Transcoders
 -----
 

--- a/c_src/callbacks.h
+++ b/c_src/callbacks.h
@@ -21,6 +21,13 @@ struct libcouchbase_callback_m {
     struct libcouchbase_callback** ret;
 };
 
+struct libcouchbase_callback_n1ql {
+	int currrow;
+	int size;
+	struct libcouchbase_callback** ret;
+	struct libcouchbase_callback* meta;
+};
+
 void get_callback(lcb_t instance,
                   const void *cookie,
                   lcb_error_t error,
@@ -57,5 +64,9 @@ void http_callback(lcb_http_request_t request,
                    const void* cookie,
                    lcb_error_t error,
                    const lcb_http_resp_t *resp);
+
+void n1ql_callback(lcb_t instance,
+					int cbtype,
+					const lcb_RESPN1QL *resp);
 
 #endif

--- a/c_src/cb.c
+++ b/c_src/cb.c
@@ -1,4 +1,5 @@
 #include <libcouchbase/couchbase.h>
+#include <libcouchbase/n1ql.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -659,6 +660,150 @@ ERL_NIF_TERM cb_http(ErlNifEnv* env, handle_t* handle, void* obj)
     free(cb.ret.data);
     free(cb.ret.key);
     return enif_make_tuple3(env, A_OK(env), enif_make_int(env, cb.status), enif_make_binary(env, &value_binary));
+}
+
+void* cb_n1ql_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+	n1ql_args_t* args = (n1ql_args_t*)enif_alloc(sizeof(n1ql_args_t));
+
+	ERL_NIF_TERM* currParam;
+	ERL_NIF_TERM tail;
+	ErlNifBinary query_binary;
+
+	if (!enif_inspect_iolist_as_binary(env, argv[0], &query_binary)) goto error0;
+	args->query = malloc(sizeof(char) * (query_binary.size + 1));
+	memset(args->query, 0, query_binary.size + 1);
+	memcpy(args->query, query_binary.data, query_binary.size);
+	args->nquery = query_binary.size;
+
+	if (!enif_get_list_length(env, argv[1], &args->numparams)) goto error1;
+	args->params = malloc(sizeof(char*) * args->numparams);
+	args->nparams = malloc(sizeof(size_t) * args->numparams);
+	currParam = malloc(sizeof(ERL_NIF_TERM));
+	tail = argv[1];
+	int i = 0;
+	while(0 != enif_get_list_cell(env, tail, currParam, &tail)) {
+		ErlNifBinary param_binary;
+		if (!enif_inspect_iolist_as_binary(env, *currParam, &param_binary)) goto error2;
+		args->params[i] = malloc(sizeof(char) * param_binary.size);
+		memcpy(args->params[i], param_binary.data, param_binary.size);
+		args->nparams[i] = param_binary.size;
+		i++;
+	}
+
+	if (!enif_get_int(env, argv[2], (int*)&args->prepared)) goto error2;
+
+	free(currParam);
+	return (void*)args;
+
+	int f = 0;
+	error2:
+		for(f = 0; f < i; f++) {
+			free(args->params[f]);
+		}
+		free(args->query);
+		free(args->params);
+		free(args->nparams);
+		free(currParam);
+	error1:
+		free(args->query);
+		enif_free(args);
+	error0:
+		enif_free(args);
+
+	return NULL;
+}
+
+ERL_NIF_TERM cb_n1ql(ErlNifEnv* env, handle_t* handle, void* obj)
+{
+	n1ql_args_t* args = (n1ql_args_t*)obj;
+	lcb_error_t ret;
+	int f = 0;
+	lcb_N1QLPARAMS *params = lcb_n1p_new();
+	lcb_CMDN1QL cmd = { 0 };
+	struct libcouchbase_callback_n1ql cb;
+
+	if (args->prepared) {
+		cmd.cmdflags |= LCB_CMDN1QL_F_PREPCACHE;
+	}
+
+	if ((ret = lcb_n1p_setstmtz(params,  args->query)) != LCB_SUCCESS) goto error0;
+
+	for(f = 0; f < args->numparams; f++) {
+		if ((ret = lcb_n1p_posparam(params, args->params[f], args->nparams[f])) != LCB_SUCCESS) goto error0;
+	}
+
+	cb.currrow = 0;
+	cb.size = 5;
+	cb.ret = malloc(sizeof(struct libcouchbase_callback*) * 1);
+	cb.meta = malloc(sizeof(struct libcouchbase_callback*) * 1);
+	cmd.callback = n1ql_callback;
+
+	if ((ret = lcb_n1p_mkcmd(params, &cmd)) != LCB_SUCCESS) goto error1;
+	if ((ret = lcb_n1ql_query(handle->instance, &cb, &cmd)) != LCB_SUCCESS) goto error1;
+	lcb_n1p_free(params);
+	lcb_wait(handle->instance);
+
+	for(f = 0; f < args->numparams; f++) {
+		free(args->params[f]);
+	}
+	free(args->query);
+	free(args->params);
+	free(args->nparams);
+
+	ERL_NIF_TERM* results;
+	ErlNifBinary databin;
+	ERL_NIF_TERM metaValue;
+	ERL_NIF_TERM returnValue;
+	results = malloc(sizeof(ERL_NIF_TERM) * cb.currrow);
+
+	// Add meta data section
+	enif_alloc_binary(cb.meta->size, &databin);
+	memcpy(databin.data, cb.meta->data, cb.meta->size);
+	metaValue = enif_make_binary(env, &databin);
+	free(cb.meta->data);
+	free(cb.meta);
+
+	int i = 0;
+	for(; i < cb.currrow; i++) {
+		if (cb.ret[i]->error == LCB_SUCCESS) {
+			enif_alloc_binary(cb.ret[i]->size, &databin);
+			memcpy(databin.data, cb.ret[i]->data, cb.ret[i]->size);
+			results[i] = enif_make_binary(env, &databin);
+		} else {
+			results[i] = enif_make_tuple1(env,
+					return_lcb_error(env, cb.ret[i]->error));
+		}
+		free(cb.ret[i]->data);
+		free(cb.ret[i]);
+	}
+	free(cb.ret);
+
+	returnValue = enif_make_list_from_array(env, results, cb.currrow);
+	free(results);
+	return enif_make_tuple3(env, A_OK(env), metaValue, returnValue);
+
+	error0:
+		free(args->query);
+		free(args->params);
+		free(args->nparams);
+		lcb_n1p_free(params);
+		for(f = 0; f < args->numparams; f++) {
+			free(args->params[f]);
+		}
+	error1:
+		free(cb.meta->data);
+		free(cb.meta);
+		free(cb.ret);
+		free(args->query);
+		free(args->params);
+		free(args->nparams);
+		lcb_n1p_free(params);
+		for(f = 0; f < args->numparams; f++) {
+			free(args->params[f]);
+		}
+
+	return return_lcb_error(env, ret);
 }
 
 ERL_NIF_TERM return_lcb_error(ErlNifEnv* env, int const value) {

--- a/c_src/cb.h
+++ b/c_src/cb.h
@@ -66,6 +66,22 @@ typedef struct http_args {
     lcb_http_type_t type;
 } http_args_t;
 
+typedef struct n1ql_args {
+    char *query;
+    unsigned int nquery;
+    void** params;
+    unsigned int numparams;
+    size_t* nparams;
+    unsigned int prepared;
+} n1ql_args_t;
+
+typedef struct n1ql_param {
+	char *parameter;
+	char *value;
+	unsigned int nparameter;
+	unsigned int nvalue;
+} n1ql_param_t;
+
 void* cb_connect_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM cb_connect(ErlNifEnv* env, handle_t* handle, void* obj);
 void* cb_store_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
@@ -82,6 +98,8 @@ void* cb_remove_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM cb_remove(ErlNifEnv* env, handle_t* handle, void* obj);
 void* cb_http_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM cb_http(ErlNifEnv* env, handle_t* handle, void* obj);
+void* cb_n1ql_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM cb_n1ql(ErlNifEnv* env, handle_t* handle, void* obj);
 
 ERL_NIF_TERM return_lcb_error(ErlNifEnv* env, int const value);
 ERL_NIF_TERM return_value(ErlNifEnv* env, void * cookie);

--- a/c_src/cberl.h
+++ b/c_src/cberl.h
@@ -2,10 +2,11 @@
 #define CBERL_H
 
 #include <libcouchbase/couchbase.h>
+#include <libcouchbase/n1ql.h>
 #include "queue.h"
 #include "erl_nif.h"
 
-#define A_OK(env)            enif_make_atom(env, "ok")
+#define A_OK(env)       enif_make_atom(env, "ok")
 #define A_ERROR(env)    enif_make_atom(env, "error")
 
 #define NIF(name)  ERL_NIF_TERM name(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/cberl_nif.c
+++ b/c_src/cberl_nif.c
@@ -44,6 +44,8 @@ NIF(cberl_nif_new)
     handle->args_calltable[CMD_REMOVE]     = cb_remove_args;
     handle->calltable[CMD_HTTP]            = cb_http;
     handle->args_calltable[CMD_HTTP]       = cb_http_args;
+    handle->calltable[CMD_N1QL]            = cb_n1ql;
+    handle->args_calltable[CMD_N1QL]       = cb_n1ql_args;
 
     handle->thread_opts = enif_thread_opts_create("thread_opts");
 

--- a/c_src/cberl_nif.h
+++ b/c_src/cberl_nif.h
@@ -13,6 +13,7 @@
 #define CMD_ARITHMETIC  5
 #define CMD_REMOVE      6
 #define CMD_HTTP        7 
+#define CMD_N1QL        8
 
 typedef struct task {
     ErlNifPid* pid;

--- a/include/cberl.hrl
+++ b/include/cberl.hrl
@@ -12,6 +12,7 @@
 -define('CMD_ARITHMETIC', 5).
 -define('CMD_REMOVE',     6).
 -define('CMD_HTTP',       7).
+-define('CMD_N1QL',       8).
 
 -type handle() :: binary().
 


### PR DESCRIPTION
- Used the same cberl connections pool name 
- N1QL query support with placeholders (current implementation do not support named placeholders)
