### PR TITLE
Return {ok,CAS::integer()} instead of ok for all store operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cberl:start_link(cberl_default, 5).
 {ok, <0.33.0>}
 % Poolname, Key, Expire - 0 for infinity, Value
 cberl:set(cberl_default, <<"fkey">>, 0, <<"cberl">>).
-ok
+{ok,CAS}
 cberl:get(cberl_default, <<"fkey">>).
 {<<"fkey">>, ReturnedCasValue, <<"cberl">>}
 ```

--- a/c_src/cb.c
+++ b/c_src/cb.c
@@ -181,7 +181,7 @@ ERL_NIF_TERM cb_store(ErlNifEnv* env, handle_t* handle, void* obj)
     if (cb.error != LCB_SUCCESS) {
         return return_lcb_error(env, cb.error);
     }
-    return A_OK(env);
+    return enif_make_tuple2(env, A_OK(env), enif_make_uint64(env, cb.cas));
 }
 
 void* cb_mget_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/include/cberl.hrl
+++ b/include/cberl.hrl
@@ -22,7 +22,7 @@
                    connected :: true | false,
                    opts :: list()}).
 
--type key() :: string().
+-type key() :: binary().
 -type value() :: string() | list() | integer() | binary().
 -type operation_type() :: add | replace | set | append | prepend.
 -type instance() :: #instance{}.

--- a/src/cberl.erl
+++ b/src/cberl.erl
@@ -73,32 +73,32 @@ stop(PoolPid) ->
 %%%%%%%%%%%%%%%%%%%%%%%%
 
 %% @equiv add(PoolPid, Key, Exp, Value, standard)
--spec add(pid(), key(), integer(), value()) -> ok | {error, _}.
+-spec add(pid(), key(), integer(), value()) -> {ok,integer()} | {error, _}.
 add(PoolPid, Key, Exp, Value) ->
     add(PoolPid, Key, Exp, Value, standard).
 
 %% @equiv store(PoolPid, add, Key, Value, TranscoderOpts, Exp, 0)
--spec add(pid(), key(), integer(), value(), atom()) -> ok | {error, _}.
+-spec add(pid(), key(), integer(), value(), atom()) -> {ok,integer()} | {error, _}.
 add(PoolPid, Key, Exp, Value, TranscoderOpts) ->
     store(PoolPid, add, Key, Value, TranscoderOpts, Exp, 0).
 
 %% @equiv replace(PoolPid, Key, Exp, Value, standard)
--spec replace(pid(), key(), integer(), value()) -> ok | {error, _}.
+-spec replace(pid(), key(), integer(), value()) -> {ok,integer()} | {error, _}.
 replace(PoolPid, Key, Exp, Value) ->
     replace(PoolPid, Key, Exp, Value, standard).
 
 %% @equiv store(PoolPid, replace, "", Key, Value, Exp)
--spec replace(pid(), key(), integer(), value(), atom()) -> ok | {error, _}.
+-spec replace(pid(), key(), integer(), value(), atom()) -> {ok,integer()} | {error, _}.
 replace(PoolPid, Key, Exp, Value, TranscoderOpts) ->
     store(PoolPid, replace, Key, Value, TranscoderOpts, Exp, 0).
 
 %% @equiv set(PoolPid, Key, Exp, Value, standard)
--spec set(pid(), key(), integer(), value()) -> ok | {error, _}.
+-spec set(pid(), key(), integer(), value()) -> {ok,integer()} | {error, _}.
 set(PoolPid, Key, Exp, Value) ->
     set(PoolPid, Key, Exp, Value, standard).
 
 %% @equiv store(PoolPid, set, "", Key, Value, Exp)
--spec set(pid(), key(), integer(), value(), atom()) -> ok | {error, _}.
+-spec set(pid(), key(), integer(), value(), atom()) -> {ok,integer()} | {error, _}.
 set(PoolPid, Key, Exp, Value, TranscoderOpts) ->
     store(PoolPid, set, Key, Value, TranscoderOpts, Exp, 0).
 
@@ -113,7 +113,7 @@ set(PoolPid, Key, Exp, Value, TranscoderOpts) ->
 append(PoolPid, _Cas, Key, Value) ->
     append(PoolPid, Key, Value).
 
--spec append(pid(), key(), value()) -> ok | {error, _}.
+-spec append(pid(), key(), value()) -> {ok,integer()} | {error, _}.
 append(PoolPid, Key, Value) ->
     store(PoolPid, append, Key, Value, none, 0, 0).
 
@@ -124,7 +124,7 @@ append(PoolPid, Key, Value) ->
 prepend(PoolPid, _Cas, Key, Value) ->
     prepend(PoolPid, Key, Value).
 
--spec prepend(pid(), key(), value()) -> ok | {error, _}.
+-spec prepend(pid(), key(), value()) -> {ok,integer()} | {error, _}.
 prepend(PoolPid, Key, Value) ->
     store(PoolPid, prepend, Key, Value, none, 0, 0).
 
@@ -212,7 +212,7 @@ unlock(PoolPid, Key, Cas) ->
 %%     pass 0 for infinity
 %% CAS
 -spec store(pid(), operation_type(), key(), value(), atom(),
-            integer(), integer()) -> ok | {error, _}.
+            integer(), integer()) -> {ok,integer()} | {error, _}.
 store(PoolPid, Op, Key, Value, TranscoderOpts, Exp, Cas) ->
     execute(PoolPid, {store, Op, Key, Value,
                        TranscoderOpts, Exp, Cas}).

--- a/src/cberl.erl
+++ b/src/cberl.erl
@@ -223,7 +223,7 @@ store(PoolPid, Op, Key, Value, TranscoderOpts, Exp, Cas) ->
 %% Key the key to get
 %% Exp When the object should expire
 %%      pass a negative number for infinity
--spec mget(pid(), [key()], integer()) -> list().
+-spec mget(pid(), [key()], integer()) -> list() | {error, _}.
 mget(PoolPid, Keys, Exp) ->
     execute(PoolPid, {mget, Keys, Exp, 0}).
 
@@ -232,7 +232,7 @@ mget(PoolPid, Keys, Exp) ->
 %%  HashKey the key to use for hashing
 %%  Key the key to get
 %%  Exp When the lock should expire
--spec getl(pid(), key(), integer()) -> list().
+-spec getl(pid(), key(), integer()) -> list() | {error, _}.
 getl(PoolPid, Key, Exp) ->
     execute(PoolPid, {mget, [Key], Exp, 1}).
 
@@ -297,7 +297,7 @@ handle_flush_result(PoolPid, FlushMarker, Result={ok, 201, _}) ->
 %% Method HTTP method
 %% Type Couchbase request type
 -spec http(pid(), string(), string(), string(), http_method(), http_type())
-	  -> {ok, binary()} | {error, _}.
+	  -> {ok, integer(), binary()} | {error, _}.
 http(PoolPid, Path, Body, ContentType, Method, Type) ->
     execute(PoolPid, {http, Path, Body, ContentType, http_method(Method), http_type(Type)}).
 


### PR DESCRIPTION
Return {ok,CAS::integer()} instead of ok for all store operations.

This saves a roundtrip when you set/add an item that you'll want to modify later.
This is a backward-incompatible change, but it seems important enough and seems to be
a coding oversight as most of the work was already done (but thrown away) in store_callback().

Also includes spec fixes that should be uncontroversial.

This is the long-delayed re-posting of PR #62 . Priorities had shifted at work and I forgot to finish this up (we were using my fork in the meantime.

As mentioned in the old PR, this commit changes the API, so you'll want to bump the version to 1.1.x to attract people's attention to the release notes. Given that n1ql support has also landed, it looks like a goo opportunity.