### PR TITLE
Return CAS value

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cberl:start_link(cberl_default, 5).
 {ok, <0.33.0>}
 % Poolname, Key, Expire - 0 for infinity, Value
 cberl:set(cberl_default, <<"fkey">>, 0, <<"cberl">>).
-ok
+{ok,CAS}
 cberl:get(cberl_default, <<"fkey">>).
 {<<"fkey">>, ReturnedCasValue, <<"cberl">>}
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CBERL
 ====
 
-[![Build Status](https://travis-ci.org/chitika/cberl.svg?branch=master)](https://travis-ci.org/chitika/cberl)
+[![Build Status](https://travis-ci.org/wcummings/cberl.svg?branch=master)](https://travis-ci.org/wcummings/cberl)
 
 NIF based Erlang bindings for couchbase based on libcouchbase. 
 CBERL is at early stage of development, it only supports very basic functionality. Please submit bugs and patches if you find any.
@@ -31,7 +31,7 @@ For installing libcouchbase on other systems visit http://www.couchbase.com/deve
 Then:
 
 ```shell
-git clone git@github.com:chitika/cberl.git
+git clone git@github.com:wcummings/cberl.git
 cd cberl
 # assuming you have rebar in your path
 rebar get-deps compile

--- a/c_src/cb.c
+++ b/c_src/cb.c
@@ -181,7 +181,7 @@ ERL_NIF_TERM cb_store(ErlNifEnv* env, handle_t* handle, void* obj)
     if (cb.error != LCB_SUCCESS) {
         return return_lcb_error(env, cb.error);
     }
-    return A_OK(env);
+    return enif_make_tuple2(env, A_OK(env), enif_make_uint64(env, cb.cas));
 }
 
 void* cb_mget_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/include/cberl.hrl
+++ b/include/cberl.hrl
@@ -22,7 +22,7 @@
                    connected :: true | false,
                    opts :: list()}).
 
--type key() :: string().
+-type key() :: binary().
 -type value() :: string() | list() | integer() | binary().
 -type operation_type() :: add | replace | set | append | prepend.
 -type instance() :: #instance{}.

--- a/src/cberl.erl
+++ b/src/cberl.erl
@@ -26,17 +26,17 @@
 -deprecated({append, 4}).
 -deprecated({prepend, 4}).
 
-%% @equiv start_link(PoolName, NumCon, "localhost:8091", "", "", "")
+%% @equiv start_link(PoolName, NumCon, "localhost:8091", "", "")
 start_link(PoolName, NumCon) ->
-    start_link(PoolName, NumCon, "localhost:8091", "", "", "").
+    start_link(PoolName, NumCon, "localhost:8091", "", "").
 
-%% @equiv start_link(PoolName, NumCon, Host, "", "", "")
+%% @equiv start_link(PoolName, NumCon, Host, "", "")
 start_link(PoolName, NumCon, Host) ->
-    start_link(PoolName, NumCon, Host, "", "", "").
+    start_link(PoolName, NumCon, Host, "", "").
 
-%% @equiv start_link(PoolName, NumCon, Host, Username, Password, "")
+%% @equiv start_link(PoolName, NumCon, Host, Username, Password, "default")
 start_link(PoolName, NumCon, Host, Username, Password) ->
-    start_link(PoolName, NumCon, Host, Username, Password, "").
+    start_link(PoolName, NumCon, Host, Username, Password, "default").
 
 %% @doc Create an instance of libcouchbase
 %% hosts A list of hosts:port separated by ';' to the

--- a/src/cberl.erl
+++ b/src/cberl.erl
@@ -73,32 +73,32 @@ stop(PoolPid) ->
 %%%%%%%%%%%%%%%%%%%%%%%%
 
 %% @equiv add(PoolPid, Key, Exp, Value, standard)
--spec add(pid(), key(), integer(), value()) -> ok | {error, _}.
+-spec add(pid(), key(), integer(), value()) -> {ok,integer()} | {error, _}.
 add(PoolPid, Key, Exp, Value) ->
     add(PoolPid, Key, Exp, Value, standard).
 
 %% @equiv store(PoolPid, add, Key, Value, TranscoderOpts, Exp, 0)
--spec add(pid(), key(), integer(), value(), atom()) -> ok | {error, _}.
+-spec add(pid(), key(), integer(), value(), atom()) -> {ok,integer()} | {error, _}.
 add(PoolPid, Key, Exp, Value, TranscoderOpts) ->
     store(PoolPid, add, Key, Value, TranscoderOpts, Exp, 0).
 
 %% @equiv replace(PoolPid, Key, Exp, Value, standard)
--spec replace(pid(), key(), integer(), value()) -> ok | {error, _}.
+-spec replace(pid(), key(), integer(), value()) -> {ok,integer()} | {error, _}.
 replace(PoolPid, Key, Exp, Value) ->
     replace(PoolPid, Key, Exp, Value, standard).
 
 %% @equiv store(PoolPid, replace, "", Key, Value, Exp)
--spec replace(pid(), key(), integer(), value(), atom()) -> ok | {error, _}.
+-spec replace(pid(), key(), integer(), value(), atom()) -> {ok,integer()} | {error, _}.
 replace(PoolPid, Key, Exp, Value, TranscoderOpts) ->
     store(PoolPid, replace, Key, Value, TranscoderOpts, Exp, 0).
 
 %% @equiv set(PoolPid, Key, Exp, Value, standard)
--spec set(pid(), key(), integer(), value()) -> ok | {error, _}.
+-spec set(pid(), key(), integer(), value()) -> {ok,integer()} | {error, _}.
 set(PoolPid, Key, Exp, Value) ->
     set(PoolPid, Key, Exp, Value, standard).
 
 %% @equiv store(PoolPid, set, "", Key, Value, Exp)
--spec set(pid(), key(), integer(), value(), atom()) -> ok | {error, _}.
+-spec set(pid(), key(), integer(), value(), atom()) -> {ok,integer()} | {error, _}.
 set(PoolPid, Key, Exp, Value, TranscoderOpts) ->
     store(PoolPid, set, Key, Value, TranscoderOpts, Exp, 0).
 
@@ -113,7 +113,7 @@ set(PoolPid, Key, Exp, Value, TranscoderOpts) ->
 append(PoolPid, _Cas, Key, Value) ->
     append(PoolPid, Key, Value).
 
--spec append(pid(), key(), value()) -> ok | {error, _}.
+-spec append(pid(), key(), value()) -> {ok,integer()} | {error, _}.
 append(PoolPid, Key, Value) ->
     store(PoolPid, append, Key, Value, none, 0, 0).
 
@@ -124,7 +124,7 @@ append(PoolPid, Key, Value) ->
 prepend(PoolPid, _Cas, Key, Value) ->
     prepend(PoolPid, Key, Value).
 
--spec prepend(pid(), key(), value()) -> ok | {error, _}.
+-spec prepend(pid(), key(), value()) -> {ok,integer()} | {error, _}.
 prepend(PoolPid, Key, Value) ->
     store(PoolPid, prepend, Key, Value, none, 0, 0).
 
@@ -212,7 +212,7 @@ unlock(PoolPid, Key, Cas) ->
 %%     pass 0 for infinity
 %% CAS
 -spec store(pid(), operation_type(), key(), value(), atom(),
-            integer(), integer()) -> ok | {error, _}.
+            integer(), integer()) -> {ok,integer()} | {error, _}.
 store(PoolPid, Op, Key, Value, TranscoderOpts, Exp, Cas) ->
     execute(PoolPid, {store, Op, Key, Value,
                        TranscoderOpts, Exp, Cas}).

--- a/src/cberl.erl
+++ b/src/cberl.erl
@@ -223,7 +223,7 @@ store(PoolPid, Op, Key, Value, TranscoderOpts, Exp, Cas) ->
 %% Key the key to get
 %% Exp When the object should expire
 %%      pass a negative number for infinity
--spec mget(pid(), [key()], integer()) -> list().
+-spec mget(pid(), [key()], integer()) -> list() | {error, _}.
 mget(PoolPid, Keys, Exp) ->
     execute(PoolPid, {mget, Keys, Exp, 0}).
 
@@ -232,7 +232,7 @@ mget(PoolPid, Keys, Exp) ->
 %%  HashKey the key to use for hashing
 %%  Key the key to get
 %%  Exp When the lock should expire
--spec getl(pid(), key(), integer()) -> list().
+-spec getl(pid(), key(), integer()) -> list() | {error, _}.
 getl(PoolPid, Key, Exp) ->
     execute(PoolPid, {mget, [Key], Exp, 1}).
 
@@ -297,7 +297,7 @@ handle_flush_result(PoolPid, FlushMarker, Result={ok, 201, _}) ->
 %% Method HTTP method
 %% Type Couchbase request type
 -spec http(pid(), string(), string(), string(), http_method(), http_type())
-	  -> {ok, binary()} | {error, _}.
+	  -> {ok, integer(), binary()} | {error, _}.
 http(PoolPid, Path, Body, ContentType, Method, Type) ->
     execute(PoolPid, {http, Path, Body, ContentType, http_method(Method), http_type(Type)}).
 


### PR DESCRIPTION
Tests pass, dialyzer is happy

This is a breaking change, but I agree w/ @vincentdephily that it is important enough. Because it affects so many functions, the alternatives would severely muddy the interface (for ex we could create a new set of store functions in a `cberl_v2` module, or a new set of functions w/ a different arity, essential a "return a cas" flag). This should be accompanied by a version bump.

https://github.com/chitika/cberl/pull/86

cc @vasumahesh1

P.S. `""` doesnt give you the default bucket anymore, this includes a commit to pass `"default"` instead